### PR TITLE
改进工作流表单中文文案与图像预览体验

### DIFF
--- a/app/jobs2.py
+++ b/app/jobs2.py
@@ -350,7 +350,7 @@ def get_workflow_form(wf):
                     _prepare_file_field(field)
             return jsonify({"ok": True, "form": form_data})
         except Exception as e:
-            return jsonify({"ok": False, "msg": f"??????: {e}"}), 400
+            return jsonify({"ok": False, "msg": f"读取表单失败: {e}"}), 400
     return jsonify({"ok": True, "form": {"name": base, "fields": [], "mapping": []}})
 
 
@@ -365,10 +365,10 @@ def create_job():
         try:
             overrides = json.loads(overrides_text)
         except Exception:
-            return jsonify({"ok": False, "msg": "overrides ?? JSON"}), 400
+            return jsonify({"ok": False, "msg": "overrides 不是合法 JSON"}), 400
     wf_path = os.path.join(PROJECT_ROOT, "workflows", wf)
     if not os.path.isfile(wf_path):
-        return jsonify({"ok": False, "msg": f"?????? {wf}"}), 404
+        return jsonify({"ok": False, "msg": f"未找到工作流 {wf}"}), 404
 
     upload_dir = current_app.config["UPLOAD_DIR"]
     os.makedirs(upload_dir, exist_ok=True)

--- a/static/app.css
+++ b/static/app.css
@@ -63,4 +63,8 @@ th{background:#0b1324; color:var(--muted); text-align:left}
 /* gallery images */
 .thumb{max-width:200px; border-radius:10px; border:1px solid var(--border)}
 
-\n.field-file select, .field-file input[type=file]{margin-bottom:6px;}\n.field-file .muted{font-size:12px;margin-top:4px;}\n.field-file .btn{margin-top:6px;}\n
+.field-file select, .field-file input[type=file]{margin-bottom:6px;}
+.field-file .muted{font-size:12px;margin-top:4px;}
+.field-file .btn{margin-top:6px;}
+.field-file .file-preview{margin-top:8px;}
+.field-file .file-preview-img{max-width:240px; border-radius:10px; border:1px solid var(--border); display:block;}

--- a/static/app_main.js
+++ b/static/app_main.js
@@ -18,11 +18,14 @@ function renderField(container, f){
 
     const existingMap = new Map();
     let select = null;
+    const fileSpec = f.file || {};
+    const fileKind = fileSpec.kind || 'image';
+
     if(Array.isArray(f.file_existing) && f.file_existing.length){
       select = document.createElement('select');
       const placeholder = document.createElement('option');
       placeholder.value = '';
-      placeholder.textContent = '??????';
+      placeholder.textContent = '请选择文件';
       select.appendChild(placeholder);
       f.file_existing.forEach(opt => {
         const option = document.createElement('option');
@@ -68,30 +71,79 @@ function renderField(container, f){
 
     const info = document.createElement('div');
     info.className = 'muted';
+    const previewBox = document.createElement('div');
+    previewBox.className = 'file-preview';
+    previewBox.style.display = 'none';
+
+    const revokePreviewUrl = () => {
+      if(previewBox.dataset.url){
+        URL.revokeObjectURL(previewBox.dataset.url);
+        delete previewBox.dataset.url;
+      }
+    };
+
+    const updatePreview = (val) => {
+      revokePreviewUrl();
+      previewBox.innerHTML = '';
+      if(!val || fileKind !== 'image'){
+        previewBox.style.display = 'none';
+        return;
+      }
+      if(val.startsWith('upload://') && fileInput && fileInput.files && fileInput.files.length){
+        const file = fileInput.files[0];
+        if(file && file.type && file.type.startsWith('image/')){
+          const url = URL.createObjectURL(file);
+          const img = document.createElement('img');
+          img.src = url;
+          img.alt = file.name || '';
+          img.className = 'file-preview-img';
+          previewBox.appendChild(img);
+          previewBox.style.display = '';
+          previewBox.dataset.url = url;
+        }else{
+          previewBox.style.display = 'none';
+        }
+        return;
+      }
+      const existing = (f.file_existing || []).find(opt => opt.value === val);
+      if(existing && existing.preview){
+        const img = document.createElement('img');
+        img.src = existing.preview;
+        img.alt = existing.label || '';
+        img.className = 'file-preview-img';
+        previewBox.appendChild(img);
+        previewBox.style.display = '';
+        return;
+      }
+      previewBox.style.display = 'none';
+    };
     const refreshInfo = () => {
       const val = hidden.value;
       if(!val){
-        info.textContent = '???';
+        info.textContent = '未选择文件';
       }else if(existingMap.has(val)){
-        info.textContent = `???${existingMap.get(val)}`;
+        info.textContent = `已选择库文件：${existingMap.get(val)}`;
       }else if(val.startsWith('upload://')){
-        info.textContent = `????${val.slice('upload://'.length)}`;
+        info.textContent = `将上传本地文件：${val.slice('upload://'.length)}`;
       }else{
         info.textContent = val;
       }
+      updatePreview(val);
     };
     refreshInfo();
     wrap.appendChild(info);
+    wrap.appendChild(previewBox);
 
     const clearBtn = document.createElement('button');
     clearBtn.type = 'button';
     clearBtn.className = 'btn ghost';
-    clearBtn.textContent = '??';
+    clearBtn.textContent = '清除';
     clearBtn.style.marginTop = '6px';
     clearBtn.addEventListener('click', () => {
       if(select){ select.value = ''; }
       if(fileInput){ fileInput.value = ''; }
       hidden.value = '';
+      revokePreviewUrl();
       refreshInfo();
     });
     wrap.appendChild(clearBtn);


### PR DESCRIPTION
## Summary
- replace placeholder question marks with clear Chinese copy for file字段和错误提示
- add client-side preview for image file inputs and dedicated styling
- tidy file field styles to show the preview container

## Testing
- Unable to run tests (依赖安装被代理阻断)

------
https://chatgpt.com/codex/tasks/task_e_68dba29c907c8324b711d458b4735d5d