### PR TITLE
Fix progress fallback when Comfy history reports stale values

### DIFF
--- a/app/jobs2.py
+++ b/app/jobs2.py
@@ -4,6 +4,7 @@ from functools import wraps
 import io, zipfile
 from datetime import datetime
 from PIL import Image
+import mimetypes
 
 jobs_bp = Blueprint("jobs", __name__)
 
@@ -49,6 +50,50 @@ def login_required(fn):
             return jsonify({"ok": False, "msg": "未登录"}), 401
         return fn(*a, **kw)
     return wrap
+
+
+def _bump_progress(job, *, step=5, ceiling=95, floor=10):
+    """Increase job.progress while keeping value within bounds."""
+    try:
+        current = float(job.get("progress") or 0)
+    except (TypeError, ValueError):
+        current = 0
+    base = current if current >= floor else floor
+    new_value = min(ceiling, base + step)
+    if new_value > current:
+        job["progress"] = int(new_value)
+
+
+def _apply_history_progress(job, history_item):
+    """Try to map ComfyUI history status fields to a percentage."""
+    status = history_item.get("status") if isinstance(history_item, dict) else None
+    if not isinstance(status, dict):
+        return False
+
+    ratios = []
+    completed = status.get("completed")
+    total = status.get("total") or status.get("max") or status.get("total_nodes")
+    ratios.append((completed, total))
+
+    # Comfy websocket progress payload sometimes uses value/max or current/total
+    ratios.append((status.get("value"), status.get("max")))
+    ratios.append((status.get("current"), status.get("total")))
+
+    best_pct = None
+    for done, total in ratios:
+        if isinstance(done, (int, float)) and isinstance(total, (int, float)) and total > 0:
+            pct = max(0, min(95, int(done / total * 100)))
+            best_pct = pct if best_pct is None else max(best_pct, pct)
+
+    if best_pct is None:
+        return False
+
+    current = job.get("progress", 0) or 0
+    if best_pct > current:
+        job["progress"] = best_pct
+        return True
+
+    return False
 
 
 def _worker():
@@ -351,12 +396,27 @@ def _run_job(job_id):
     deadline = time.time() + 600
     outputs = []
     while time.time() < deadline:
-        h = requests.get(f"{comfy}/history/{prompt_id}", timeout=30)
+        try:
+            h = requests.get(f"{comfy}/history/{prompt_id}", timeout=30)
+        except requests.RequestException:
+            _bump_progress(j, step=2, ceiling=90)
+            time.sleep(1)
+            continue
         if h.status_code != 200:
-            time.sleep(1); continue
-        item = (h.json() or {}).get(prompt_id)
+            _bump_progress(j, step=2, ceiling=90)
+            time.sleep(1)
+            continue
+        try:
+            payload = h.json() or {}
+        except ValueError:
+            _bump_progress(j, step=2, ceiling=90)
+            time.sleep(1)
+            continue
+        item = payload.get(prompt_id)
         if not item:
-            time.sleep(1); continue
+            _bump_progress(j, step=2, ceiling=90)
+            time.sleep(1)
+            continue
         if item.get("node_errors"):
             j.update(status="error", error=str(item.get("node_errors")))
             return
@@ -370,7 +430,8 @@ def _run_job(job_id):
                 })
         if outputs:
             break
-        j["progress"] = min(95, j.get("progress", 10) + 5)
+        if not _apply_history_progress(j, item):
+            _bump_progress(j)
         time.sleep(1)
     if not outputs:
         j.update(status="timeout", progress=100, done_at=time.time()); return


### PR DESCRIPTION
## Summary
- only treat ComfyUI history progress as authoritative when it advances beyond the current value
- allow the fallback bumper to keep advancing when the history response never increases

## Testing
- python -m compileall app/jobs2.py

------
https://chatgpt.com/codex/tasks/task_e_68df3a406ce88324b90b48c356e98fa1