### PR TITLE
feat: surface non-image workflow outputs in portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ tmp/
 
 # local backups
 app/jobs2.py.bak.*
+project_backup_*.tar.gz
 

--- a/README.md
+++ b/README.md
@@ -171,3 +171,22 @@
 - 部署后至少验证一次：提交任务 → 轮询进度 → 预览缩略图 → 下载 ZIP。
 - 修改工作流或表单后同步更新 `servers.json` 映射。
 - 建议定期备份 `workflows/`、`users.csv`、`assets/` 和结果目录。
+
+## 发布与回滚流程
+1. **在打标签或部署前保持工作区干净**
+   - 运行 `git status`，确保没有待提交的修改。
+   - 若看到 `workflows/servers.json` 等环境私有配置有改动，可用 `git restore workflows/servers.json` 或 `git checkout -- workflows/servers.json` 恢复到仓库版本；如需长期保留本地改动，可在单独分支或私有仓库维护。
+   - 对于 `.tar.gz` 备份包等临时文件，可执行 `git clean -f` 或手动删除；仓库已忽略 `project_backup_*.tar.gz`，避免误加入提交。
+   - 如需暂存本地修改以便稍后恢复，可用 `git stash push --include-untracked`。
+2. **创建版本标签**
+   ```bash
+   git tag -a vX.Y.Z -m "Stable portal release"
+   git push origin vX.Y.Z
+   ```
+   版本号可按团队约定调整，建议同时在 Release Notes/CHANGELOG 中记录关键变更。
+3. **部署指定标签**
+   - 手工部署时执行 `git fetch --tags` 后 `git checkout vX.Y.Z`，再重启服务进程。
+   - CI/CD 可将目标标签作为参数传入，保证线上环境始终指向明确版本。
+4. **需要回滚时**
+   - 直接切换到旧标签或基于标签创建 hotfix 分支：`git checkout vPrevious` 或 `git checkout -b hotfix/<issue> vPrevious`。
+   - 修复后重新打标签并部署。

--- a/app/jobs2.py
+++ b/app/jobs2.py
@@ -4,6 +4,7 @@ from functools import wraps
 import io, zipfile
 from datetime import datetime
 from PIL import Image
+import mimetypes
 
 jobs_bp = Blueprint("jobs", __name__)
 
@@ -49,6 +50,50 @@ def login_required(fn):
             return jsonify({"ok": False, "msg": "未登录"}), 401
         return fn(*a, **kw)
     return wrap
+
+
+def _bump_progress(job, *, step=5, ceiling=95, floor=10):
+    """Increase job.progress while keeping value within bounds."""
+    try:
+        current = float(job.get("progress") or 0)
+    except (TypeError, ValueError):
+        current = 0
+    base = current if current >= floor else floor
+    new_value = min(ceiling, base + step)
+    if new_value > current:
+        job["progress"] = int(new_value)
+
+
+def _apply_history_progress(job, history_item):
+    """Try to map ComfyUI history status fields to a percentage."""
+    status = history_item.get("status") if isinstance(history_item, dict) else None
+    if not isinstance(status, dict):
+        return False
+
+    ratios = []
+    completed = status.get("completed")
+    total = status.get("total") or status.get("max") or status.get("total_nodes")
+    ratios.append((completed, total))
+
+    # Comfy websocket progress payload sometimes uses value/max or current/total
+    ratios.append((status.get("value"), status.get("max")))
+    ratios.append((status.get("current"), status.get("total")))
+
+    best_pct = None
+    for done, total in ratios:
+        if isinstance(done, (int, float)) and isinstance(total, (int, float)) and total > 0:
+            pct = max(0, min(95, int(done / total * 100)))
+            best_pct = pct if best_pct is None else max(best_pct, pct)
+
+    if best_pct is None:
+        return False
+
+    current = job.get("progress", 0) or 0
+    if best_pct > current:
+        job["progress"] = best_pct
+        return True
+
+    return False
 
 
 def _worker():
@@ -350,31 +395,86 @@ def _run_job(job_id):
     # poll history
     deadline = time.time() + 600
     outputs = []
+    file_outputs = []  # 记录可下载产物，用于 ZIP
     while time.time() < deadline:
-        h = requests.get(f"{comfy}/history/{prompt_id}", timeout=30)
+        try:
+            h = requests.get(f"{comfy}/history/{prompt_id}", timeout=30)
+        except requests.RequestException:
+            _bump_progress(j, step=2, ceiling=90)
+            time.sleep(1)
+            continue
         if h.status_code != 200:
-            time.sleep(1); continue
-        item = (h.json() or {}).get(prompt_id)
+            _bump_progress(j, step=2, ceiling=90)
+            time.sleep(1)
+            continue
+        try:
+            payload = h.json() or {}
+        except ValueError:
+            _bump_progress(j, step=2, ceiling=90)
+            time.sleep(1)
+            continue
+        item = payload.get(prompt_id)
         if not item:
-            time.sleep(1); continue
+            _bump_progress(j, step=2, ceiling=90)
+            time.sleep(1)
+            continue
         if item.get("node_errors"):
             j.update(status="error", error=str(item.get("node_errors")))
             return
         outs = item.get("outputs") or {}
         for node_out in outs.values():
             for img in node_out.get("images", []):
-                outputs.append({
+                artifact = {
+                    "kind": "image",
                     "filename": img.get("filename"),
                     "subfolder": img.get("subfolder", ""),
                     "type": img.get("type", "output")
-                })
+                }
+                outputs.append(artifact)
+                file_outputs.append(artifact)
+
+            for audio in node_out.get("audio", []):
+                artifact = {
+                    "kind": "audio",
+                    "filename": audio.get("filename"),
+                    "subfolder": audio.get("subfolder", ""),
+                    "type": audio.get("type", "output"),
+                    "format": audio.get("format") or audio.get("mime", "")
+                }
+                outputs.append(artifact)
+                file_outputs.append(artifact)
+
+            for file_item in node_out.get("files", []):
+                artifact = {
+                    "kind": file_item.get("kind") or "file",
+                    "filename": file_item.get("filename"),
+                    "subfolder": file_item.get("subfolder", ""),
+                    "type": file_item.get("type", "output"),
+                }
+                outputs.append(artifact)
+                file_outputs.append(artifact)
+
+            for text_item in node_out.get("text", []):
+                if isinstance(text_item, dict):
+                    content = text_item.get("text") or text_item.get("content") or ""
+                    extra = {k: v for k, v in text_item.items() if k not in {"text", "content"}}
+                else:
+                    content = str(text_item)
+                    extra = {}
+                if content:
+                    artifact = {"kind": "text", "text": content}
+                    if extra:
+                        artifact.update({"meta": extra})
+                    outputs.append(artifact)
+
         if outputs:
             break
-        j["progress"] = min(95, j.get("progress", 10) + 5)
+        if not _apply_history_progress(j, item):
+            _bump_progress(j)
         time.sleep(1)
     if not outputs:
         j.update(status="timeout", progress=100, done_at=time.time()); return
-    j.update(status="finished", progress=100, outputs=outputs, done_at=time.time())
+    j.update(status="finished", progress=100, outputs=outputs, done_at=time.time(), file_outputs=file_outputs)
 
 
 def _list_workflows_impl():
@@ -618,7 +718,7 @@ def download_zip(job_id):
     j = _jobs.get(job_id)
     if not j:
         return jsonify({"ok": False, "msg": "不存在的任务"}), 404
-    artifacts = j.get("outputs", [])
+    artifacts = j.get("file_outputs") or [a for a in j.get("outputs", []) if a.get("filename")]
     if not artifacts:
         return jsonify({"ok": False, "msg": "该任务没有可下载的产物"}), 400
     comfy = j.get("comfy_url") or _comfy_url()

--- a/static/app.css
+++ b/static/app.css
@@ -63,8 +63,17 @@ th{background:#0b1324; color:var(--muted); text-align:left}
 /* gallery images */
 .thumb{max-width:200px; border-radius:10px; border:1px solid var(--border)}
 
+.artifact{display:inline-block; vertical-align:top; margin:6px; padding:10px; border:1px solid var(--border); border-radius:12px; background:#0b1324b3; max-width:260px; min-width:200px;}
+.artifact img.thumb{display:block; margin:0 auto 8px;}
+.artifact audio{width:100%; margin:8px 0;}
+.artifact-caption{font-size:13px; color:var(--muted); margin-bottom:6px;}
+.artifact-text{max-width:420px; display:block;}
+.artifact-text pre{margin:0; white-space:pre-wrap; word-break:break-word;}
+.artifact-zip{margin:10px 4px;}
+
 .field-file select, .field-file input[type=file]{margin-bottom:6px;}
 .field-file .muted{font-size:12px;margin-top:4px;}
 .field-file .btn{margin-top:6px;}
 .field-file .file-preview{margin-top:8px;}
 .field-file .file-preview-img{max-width:240px; border-radius:10px; border:1px solid var(--border); display:block;}
+.field-file .file-preview-audio{width:100%; max-width:260px; display:block;}

--- a/static/app_main.js
+++ b/static/app_main.js
@@ -1,6 +1,15 @@
 // ComfyUI Portal main page logic
 const $ = (s)=>document.querySelector(s);
 
+function escapeHtml(str){
+  return (str ?? '').toString()
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 function renderField(container, f){
   const wrap = document.createElement('div');
   wrap.className = 'field';
@@ -85,36 +94,76 @@ function renderField(container, f){
     const updatePreview = (val) => {
       revokePreviewUrl();
       previewBox.innerHTML = '';
-      if(!val || fileKind !== 'image'){
+      if(!val){
         previewBox.style.display = 'none';
         return;
       }
-      if(val.startsWith('upload://') && fileInput && fileInput.files && fileInput.files.length){
-        const file = fileInput.files[0];
-        if(file && file.type && file.type.startsWith('image/')){
-          const url = URL.createObjectURL(file);
+
+      if(fileKind === 'image'){
+        if(val.startsWith('upload://') && fileInput && fileInput.files && fileInput.files.length){
+          const file = fileInput.files[0];
+          if(file && file.type && file.type.startsWith('image/')){
+            const url = URL.createObjectURL(file);
+            const img = document.createElement('img');
+            img.src = url;
+            img.alt = file.name || '';
+            img.className = 'file-preview-img';
+            previewBox.appendChild(img);
+            previewBox.style.display = '';
+            previewBox.dataset.url = url;
+          }else{
+            previewBox.style.display = 'none';
+          }
+          return;
+        }
+        const existing = (f.file_existing || []).find(opt => opt.value === val);
+        if(existing && existing.preview){
           const img = document.createElement('img');
-          img.src = url;
-          img.alt = file.name || '';
+          img.src = existing.preview;
+          img.alt = existing.label || '';
           img.className = 'file-preview-img';
           previewBox.appendChild(img);
           previewBox.style.display = '';
-          previewBox.dataset.url = url;
-        }else{
-          previewBox.style.display = 'none';
+          return;
         }
+        previewBox.style.display = 'none';
         return;
       }
-      const existing = (f.file_existing || []).find(opt => opt.value === val);
-      if(existing && existing.preview){
-        const img = document.createElement('img');
-        img.src = existing.preview;
-        img.alt = existing.label || '';
-        img.className = 'file-preview-img';
-        previewBox.appendChild(img);
-        previewBox.style.display = '';
+
+      if(fileKind === 'audio'){
+        const buildAudio = (src, label) => {
+          const audio = document.createElement('audio');
+          audio.controls = true;
+          audio.preload = 'none';
+          audio.src = src;
+          audio.className = 'file-preview-audio';
+          if(label){ audio.setAttribute('aria-label', label); }
+          previewBox.appendChild(audio);
+          previewBox.style.display = '';
+        };
+
+        if(val.startsWith('upload://') && fileInput && fileInput.files && fileInput.files.length){
+          const file = fileInput.files[0];
+          if(file && file.type && file.type.startsWith('audio/')){
+            const url = URL.createObjectURL(file);
+            buildAudio(url, file.name || '');
+            previewBox.dataset.url = url;
+          }else{
+            previewBox.style.display = 'none';
+          }
+          return;
+        }
+
+        const existing = (f.file_existing || []).find(opt => opt.value === val);
+        if(existing && existing.preview){
+          buildAudio(existing.preview, existing.label || '');
+          return;
+        }
+
+        previewBox.style.display = 'none';
         return;
       }
+
       previewBox.style.display = 'none';
     };
     const refreshInfo = () => {
@@ -280,14 +329,33 @@ function bindPoll(){
         const show = (j.status==='queued' || j.status==='submitting' || j.status==='running');
         pw.style.display = show ? 'block' : 'none';
       }
-      if(j.ok && j.outputs){
-        const imgs = (j.outputs||[]).map(o=>{
-          const url = `/api/jobs/${id}/comfy/view?filename=${encodeURIComponent(o.filename)}&subfolder=${encodeURIComponent(o.subfolder||'')}&type=${encodeURIComponent(o.type||'output')}`;
-          const dl = `/api/jobs/${id}/download?filename=${encodeURIComponent(o.filename)}&subfolder=${encodeURIComponent(o.subfolder||'')}&type=${encodeURIComponent(o.type||'output')}`;
-          return `<div style=\"display:inline-block;text-align:center;margin:4px\"><img class=\"thumb\" style=\"max-width:180px;display:block\" src=\"${url}\" /><a href=\"${dl}\">下载</a></div>`
+      if(j.ok && Array.isArray(j.outputs) && j.outputs.length){
+        const outputs = j.outputs || [];
+        const fileOutputs = (j.file_outputs || outputs).filter(o => o && o.filename);
+        const parts = outputs.map(o => {
+          if(!o){ return ''; }
+          if(o.kind === 'text' && o.text){
+            return `<div class=\"artifact artifact-text\"><div class=\"artifact-caption\">文本输出</div><pre>${escapeHtml(o.text)}</pre></div>`;
+          }
+          if(o.kind === 'audio' && o.filename){
+            const url = `/api/jobs/${id}/comfy/view?filename=${encodeURIComponent(o.filename)}&subfolder=${encodeURIComponent(o.subfolder||'')}&type=${encodeURIComponent(o.type||'output')}`;
+            const dl = `/api/jobs/${id}/download?filename=${encodeURIComponent(o.filename)}&subfolder=${encodeURIComponent(o.subfolder||'')}&type=${encodeURIComponent(o.type||'output')}`;
+            return `<div class=\"artifact artifact-audio\"><div class=\"artifact-caption\">音频输出：${escapeHtml(o.filename || '')}</div><audio controls preload=\"none\" src=\"${url}\"></audio><div><a href=\"${dl}\">下载</a></div></div>`;
+          }
+          if(o.kind === 'image' && o.filename){
+            const url = `/api/jobs/${id}/comfy/view?filename=${encodeURIComponent(o.filename)}&subfolder=${encodeURIComponent(o.subfolder||'')}&type=${encodeURIComponent(o.type||'output')}`;
+            const dl = `/api/jobs/${id}/download?filename=${encodeURIComponent(o.filename)}&subfolder=${encodeURIComponent(o.subfolder||'')}&type=${encodeURIComponent(o.type||'output')}`;
+            return `<div class=\"artifact artifact-image\"><img class=\"thumb\" src=\"${url}\" alt=\"${escapeHtml(o.filename || '')}\" /><div><a href=\"${dl}\">下载</a></div></div>`;
+          }
+          if(o.filename){
+            const url = `/api/jobs/${id}/comfy/view?filename=${encodeURIComponent(o.filename)}&subfolder=${encodeURIComponent(o.subfolder||'')}&type=${encodeURIComponent(o.type||'output')}`;
+            const dl = `/api/jobs/${id}/download?filename=${encodeURIComponent(o.filename)}&subfolder=${encodeURIComponent(o.subfolder||'')}&type=${encodeURIComponent(o.type||'output')}`;
+            return `<div class=\"artifact\"><div class=\"artifact-caption\">${escapeHtml(o.filename || '文件')}</div><a href=\"${url}\" target=\"_blank\">预览</a> · <a href=\"${dl}\">下载</a></div>`;
+          }
+          return '';
         }).join('');
-        const zip = `<div style=\"margin:8px 0\"><a href=\"/api/jobs/${id}/download.zip\">下载全部为 ZIP</a></div>`;
-        document.getElementById('images').innerHTML = zip + imgs;
+        const zip = fileOutputs.length ? `<div class=\"artifact-zip\"><a href=\"/api/jobs/${id}/download.zip\">下载全部文件为 ZIP</a></div>` : '';
+        document.getElementById('images').innerHTML = zip + parts;
       } else if(j.ok && (j.status==='queued' || j.status==='running' || j.status==='submitting')){
         setTimeout(step, 1200);
       }


### PR DESCRIPTION
## Summary
- capture audio, generic files, and text payloads from Comfy history while keeping a filtered file list for ZIP downloads
- render text excerpts and audio players on the main portal page with HTML escaping and unified artifact styling
- add CSS blocks for the new artifact cards so different output types align with the existing gallery

## Testing
- python -m compileall app/jobs2.py

------
https://chatgpt.com/codex/tasks/task_e_68df3a406ce88324b90b48c356e98fa1