### PR TITLE
Handle HTML error responses in job submission

### DIFF
--- a/static/app.css
+++ b/static/app.css
@@ -43,6 +43,8 @@ input:focus, textarea:focus, select:focus{border-color:#3f62a8; box-shadow:0 0 0
 .btn:hover{filter:brightness(1.05)}
 .btn.ghost{background:transparent; border-color:var(--border); color:var(--text)}
 .btn.danger{background:linear-gradient(90deg, #ff6b7a, #ff4d65)}
+.btn:disabled{opacity:.6; cursor:not-allowed; filter:none}
+.btn:disabled:hover{filter:none}
 
 .muted{color:var(--muted)}
 pre{background:#0b1324; border:1px solid var(--border); border-radius:12px; padding:12px; overflow:auto}

--- a/static/app_main.js
+++ b/static/app_main.js
@@ -254,12 +254,26 @@ function renderField(container, f){
   container.appendChild(wrap);
 }
 
-
+async function parseJsonResponse(res, context){
+  const raw = await res.text();
+  if(!raw){
+    if(res.ok){ return {}; }
+    throw new Error(`${context}：服务器返回空响应（${res.status} ${res.statusText}）`);
+  }
+  try{
+    return JSON.parse(raw);
+  }catch(err){
+    const type = res.headers && res.headers.get ? (res.headers.get('content-type') || '未知类型') : '未知类型';
+    const snippet = raw.replace(/\s+/g, ' ').trim().slice(0, 160);
+    const extra = snippet ? ` 内容片段：${snippet}` : '';
+    throw new Error(`${context}：服务器返回了无法解析的响应（${res.status} ${res.statusText}，${type}）。${extra}`);
+  }
+}
 
 async function authGuard(){
   const r = await fetch('/auth/status');
   if(r.status === 401){ location.href = '/login'; return false; }
-  const j = await r.json();
+  const j = await parseJsonResponse(r, '获取登录状态');
   const bar = document.getElementById('userbar');
   const adminLink = j.role==='admin' ? ` | <a class="pill" href="/admin/settings">后台</a>` : '';
   bar.innerHTML = `已登录：${(j.user||'')}${adminLink} <a class="pill" href="/logout_page" style="margin-left:8px">退出</a>`;
@@ -268,38 +282,109 @@ async function authGuard(){
 
 async function loadWorkflows(){
   const sel = document.getElementById('wfSelect');
-  const resp = await fetch('/api/workflows'); const j = await resp.json();
+  const resp = await fetch('/api/workflows'); const j = await parseJsonResponse(resp, '加载工作流列表');
   sel.innerHTML = '';
   (j.items||[]).forEach(it=>{ const o=document.createElement('option'); o.value=it.workflow; o.textContent=it.workflow+(it.has_form?'':' (无表单)'); sel.appendChild(o)});
   if(j.items&&j.items.length){ sel.value = j.items[0].workflow; document.getElementById('wfInput').value = sel.value; await loadForm(sel.value); }
   sel.onchange = async ()=>{ document.getElementById('wfInput').value = sel.value; await loadForm(sel.value); };
 }
 
+let submitCooldownTimer = null;
+
+function startSubmitCooldown(seconds, prefixText){
+  const submitBtn = document.querySelector('#jobForm button[type="submit"]');
+  const respEl = document.getElementById('createResp');
+  if(!submitBtn || !respEl){ return; }
+  if(submitCooldownTimer){
+    clearInterval(submitCooldownTimer);
+    submitCooldownTimer = null;
+  }
+  let remaining = Math.max(0, seconds|0);
+  const formatMessage = () => {
+    const countdownText = `您在“${remaining}”秒之后才能再次提交`;
+    if(prefixText){
+      const suffix = prefixText.endsWith('。') ? '' : '。';
+      respEl.textContent = `${prefixText}${suffix}${countdownText}`;
+    }else{
+      respEl.textContent = countdownText;
+    }
+  };
+  submitBtn.disabled = true;
+  formatMessage();
+  if(remaining <= 0){
+    submitBtn.disabled = false;
+    if(prefixText){ respEl.textContent = prefixText; }
+    return;
+  }
+  submitCooldownTimer = setInterval(() => {
+    remaining -= 1;
+    if(remaining <= 0){
+      clearInterval(submitCooldownTimer);
+      submitCooldownTimer = null;
+      submitBtn.disabled = false;
+      if(prefixText){
+        respEl.textContent = prefixText;
+      }else{
+        respEl.textContent = '';
+      }
+      return;
+    }
+    formatMessage();
+  }, 1000);
+}
+
 async function loadForm(wfname){
   const area = document.getElementById('formFields'); area.innerHTML='';
-  const r = await fetch(`/api/workflows/${encodeURIComponent(wfname)}/form`); const j = await r.json();
+  const r = await fetch(`/api/workflows/${encodeURIComponent(wfname)}/form`); const j = await parseJsonResponse(r, '加载表单');
   const fields = (j.form && j.form.fields) || [];
   if(!fields.length){ area.innerHTML = '<div class="muted">该工作流暂未提供表单定义，可直接提交。</div>'; }
   fields.forEach(f=>renderField(area, f));
 }
 
 function bindSubmit(){
-  document.getElementById('jobForm').addEventListener('submit', async (e)=>{
+  const form = document.getElementById('jobForm');
+  const submitBtn = form.querySelector('button[type="submit"]');
+  form.addEventListener('submit', async (e)=>{
     e.preventDefault();
+    if(submitBtn){ submitBtn.disabled = true; }
     const fd = new FormData(e.target);
+    let cooldownStarted = false;
     try{
       const res = await fetch('/api/jobs', {method:'POST', body:fd});
-      const j = await res.json();
-      document.getElementById('createResp').textContent = JSON.stringify(j);
-      if(j.ok){ document.getElementById('jobId').value = j.job_id; }
-    }catch(err){ document.getElementById('createResp').textContent = err+''; }
+      let j;
+      try{
+        j = await parseJsonResponse(res, '提交任务');
+      }catch(parseErr){
+        document.getElementById('createResp').textContent = `提交失败：${parseErr.message || parseErr}`;
+        return;
+      }
+      if(!res.ok && !j.ok){
+        const msg = j && (j.error || j.message);
+        const fallback = `服务器返回错误（${res.status} ${res.statusText}）`;
+        document.getElementById('createResp').textContent = `提交失败：${msg || fallback}`;
+        return;
+      }
+      if(j.ok){
+        if(j.job_id){ document.getElementById('jobId').value = j.job_id; }
+        const successText = `提交成功，任务 ID：${j.job_id || ''}`.trim();
+        startSubmitCooldown(120, successText);
+        cooldownStarted = true;
+      }else{
+        const msg = j.error ? `提交失败：${j.error}` : '提交失败，请稍后重试。';
+        document.getElementById('createResp').textContent = msg;
+      }
+    }catch(err){
+      document.getElementById('createResp').textContent = `提交失败：${err}`;
+    }finally{
+      if(!cooldownStarted && submitBtn){ submitBtn.disabled = false; }
+    }
   });
 }
 
 async function updateQueue(){
   try{
     const r = await fetch('/api/queue');
-    const j = await r.json();
+    const j = await parseJsonResponse(r, '获取队列信息');
     if(j && typeof j.queued !== 'undefined'){
       document.getElementById('queueCount').textContent = j.queued;
     }
@@ -311,8 +396,17 @@ function bindPoll(){
     const id = document.getElementById('jobId').value.trim();
     if(!id) return;
     async function step(){
-      const r = await fetch(`/api/jobs/${id}/status`);
-      const j = await r.json();
+      let j;
+      try{
+        const r = await fetch(`/api/jobs/${id}/status`);
+        j = await parseJsonResponse(r, '获取任务状态');
+      }catch(err){
+        console.error(err);
+        document.getElementById('stateText').textContent = '获取任务状态失败';
+        const detailErr = document.getElementById('detailsPre');
+        if(detailErr) detailErr.textContent = `${err}`;
+        return;
+      }
       // 仅在详情中保留原始 JSON
       const detail = document.getElementById('detailsPre');
       if(detail) detail.textContent = JSON.stringify(j,null,2);


### PR DESCRIPTION
## Summary
- add a shared helper to safely parse API JSON responses and surface descriptive errors when the backend returns HTML
- guard the job submission flow against non-JSON replies so the cooldown button re-enables correctly
- reuse the safe JSON parser when polling and loading data to prevent crashes and show a friendly status message if parsing fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4850e8388832480653c00337a8650