### PR TITLE
Treat L16 video workflows as long-running tasks

### DIFF
--- a/app/jobs2.py
+++ b/app/jobs2.py
@@ -265,6 +265,20 @@ def _prepare_file_field(field):
             existing.append({'label': entry, 'value': f'existing://{idx}/{entry}', 'preview': f"/api/assets/preview?dir={rel_dir}&name={entry}"})
     if existing:
         field['file_existing'] = existing
+        default = field.get('default')
+        if isinstance(default, str) and default and not default.startswith('existing://'):
+            # 尝试按文件名或标签匹配默认值
+            match = None
+            for item in existing:
+                if default == item.get('value'):
+                    match = item
+                    break
+                label = item.get('label')
+                if label and (default == label or default == os.path.basename(label)):
+                    match = item
+                    break
+            if match:
+                field['default'] = match.get('value')
     if spec.get('accept') and 'accept' not in field:
         field['accept'] = spec['accept']
     if 'allow_upload' not in field:
@@ -279,6 +293,109 @@ def _guess_file_kind(filename):
     if lower.endswith(('.mp4', '.mov', '.mkv', '.avi', '.webm')):
         return 'video'
     return 'image'
+
+
+_ERROR_STATUS_VALUES = {"error", "failed", "cancelled", "canceled"}
+
+
+def _stringify(value):
+    if value is None:
+        return ''
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except Exception:
+        return str(value)
+
+
+def _localize_error_message(message):
+    text = _stringify(message).strip()
+    if not text:
+        return ''
+    lower = text.lower()
+    if 'input audio duration' in lower and 'infer audio duration' in lower:
+        return '音频时长与生成时长不匹配，请检查“音频时长(秒)”与“生成时长(秒)”字段。'
+    if 'bbox_s' in lower and 'referenced before assignment' in lower:
+        return '人脸检测失败，请使用清晰的正面人像图片或调整扩展比例后重试。'
+    if 'value not in list' in lower:
+        return text.replace('Value not in list', '选项不在允许列表中')
+    return text
+
+
+def _summarize_node_errors(node_errors):
+    if isinstance(node_errors, dict):
+        parts = []
+        for node_id, info in node_errors.items():
+            label = info.get('title') or info.get('label') or info.get('class_type') or f'节点 {node_id}'
+            errors = info.get('errors') or []
+            if not errors:
+                parts.append(f"{label}：出现未知错误")
+                continue
+            for err in errors:
+                message = err.get('message') or err.get('type') or ''
+                details = err.get('details')
+                extra_bits = []
+                if isinstance(details, dict):
+                    input_name = details.get('input_name')
+                    if input_name:
+                        extra_bits.append(f"字段 {input_name}")
+                    received = details.get('received_value')
+                    if received:
+                        extra_bits.append(f"收到值：{received}")
+                    input_config = details.get('input_config')
+                    if isinstance(input_config, (list, tuple)) and input_config:
+                        allowed = input_config[0]
+                        if isinstance(allowed, (list, tuple)) and allowed:
+                            allowed_str = '、'.join(str(v) for v in allowed)
+                            if allowed_str:
+                                extra_bits.append(f"允许值：{allowed_str}")
+                elif isinstance(details, (list, tuple)):
+                    detail_text = '、'.join(_stringify(v) for v in details if v)
+                    if detail_text:
+                        extra_bits.append(detail_text)
+                elif isinstance(details, str) and details:
+                    extra_bits.append(details)
+                if extra_bits:
+                    detail_text = '，'.join(extra_bits)
+                    message = f"{message}（{detail_text}）" if message else detail_text
+                parts.append(f"{label}：{_localize_error_message(message)}")
+        return '；'.join(parts)
+    if isinstance(node_errors, list):
+        return '；'.join(_localize_error_message(err) for err in node_errors if err)
+    return _localize_error_message(node_errors)
+
+
+def _history_status_failed(status_info):
+    if isinstance(status_info, dict):
+        status_value = status_info.get('status') or status_info.get('state')
+    else:
+        status_value = status_info
+    if not isinstance(status_value, str):
+        return False
+    return status_value.lower() in _ERROR_STATUS_VALUES
+
+
+def _extract_history_error(item):
+    if not isinstance(item, dict):
+        return ''
+    status_info = item.get('status')
+    if isinstance(status_info, dict):
+        for key in ('error', 'message', 'reason', 'info', 'detail'):
+            val = status_info.get(key)
+            if val:
+                return _stringify(val)
+        messages = status_info.get('messages')
+        if isinstance(messages, (list, tuple)):
+            joined = '；'.join(_stringify(m) for m in messages if m)
+            if joined:
+                return joined
+        if isinstance(messages, str) and messages:
+            return messages
+    for key in ('error', 'exception_message', 'exception', 'traceback'):
+        if item.get(key):
+            return _stringify(item.get(key))
+    return ''
 
 
 def _resolve_existing_file(field, value):
@@ -310,6 +427,74 @@ def _resolve_existing_file(field, value):
     if not os.path.isfile(candidate):
         return None
     return candidate
+
+
+_VIDEO_EXTS = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".mpg", ".mpeg"}
+_AUDIO_EXTS = {".wav", ".mp3", ".flac", ".aac", ".ogg", ".m4a"}
+
+
+def _normalize_artifact(data, *, default_kind=None):
+    if not isinstance(data, dict):
+        return None
+    filename = data.get("filename") or data.get("name")
+    if not filename:
+        return None
+    subfolder = data.get("subfolder", "")
+    typ = data.get("type", "output")
+    fmt = data.get("format") or data.get("mime") or data.get("mimetype")
+    kind = data.get("kind") or default_kind
+
+    if not kind and isinstance(fmt, str):
+        if fmt.startswith("video/"):
+            kind = "video"
+        elif fmt.startswith("audio/"):
+            kind = "audio"
+        elif fmt.startswith("image/"):
+            kind = "image"
+
+    if not kind:
+        ext = os.path.splitext(filename)[1].lower()
+        if ext in _VIDEO_EXTS:
+            kind = "video"
+        elif ext in _AUDIO_EXTS:
+            kind = "audio"
+        elif ext in {".png", ".jpg", ".jpeg", ".bmp", ".gif", ".webp"}:
+            kind = "image"
+
+    if not kind:
+        kind = "file"
+
+    artifact = {
+        "kind": kind,
+        "filename": filename,
+        "subfolder": subfolder,
+        "type": typ,
+    }
+
+    if fmt:
+        artifact["format"] = fmt
+    elif kind in {"video", "audio"}:
+        guess = mimetypes.guess_type(filename)[0]
+        if guess:
+            artifact["format"] = guess
+
+    if data.get("text") and kind == "text":
+        artifact["text"] = data.get("text")
+
+    return artifact
+
+
+def _add_artifact(artifact, outputs, file_outputs, seen):
+    if not artifact:
+        return
+    outputs.append(artifact)
+    fname = artifact.get("filename")
+    if fname:
+        key = (fname, artifact.get("subfolder", ""), artifact.get("type", "output"))
+        if key in seen:
+            return
+        seen.add(key)
+        file_outputs.append(artifact)
 
 
 def _deep_set(obj, path, value):
@@ -390,17 +575,10 @@ def _upload_to_comfy(file_path, kind='image', comfy_base=None):
     - Auto converts .webp to .png for compatibility
     Returns: filename on Comfy side
     """
-    import io as _io, os as _os, requests as _requests
+    import io as _io, os as _os, mimetypes as _mimetypes, requests as _requests
 
     if comfy_base is None:
         comfy_base = _comfy_url()
-
-    endpoint = 'image'
-    field = 'image'
-    if kind == 'audio':
-        endpoint = 'audio'; field = 'audio'
-    elif kind == 'video':
-        endpoint = 'video'; field = 'video'
 
     basename = _os.path.basename(file_path)
     ext = _os.path.splitext(basename)[1].lower()
@@ -416,24 +594,67 @@ def _upload_to_comfy(file_path, kind='image', comfy_base=None):
             _img.save(_buf, format='PNG')
             _buf.seek(0)
             newname = _os.path.splitext(basename)[0] + '.png'
-            files = {field: (newname, _buf, 'image/png')}
+            file_handle = _buf
+            upload_name = newname
+            mime = 'image/png'
         else:
             fp = open(file_path, 'rb')
-            files = {field: (basename, fp)}
+            file_handle = fp
+            upload_name = basename
+            mime = _mimetypes.guess_type(basename)[0]
 
-        url = f"{comfy_base}/upload/{endpoint}"
-        r = _requests.post(url, files=files, data={'type':'input','subfolder':''}, timeout=120)
+        def _build_candidates():
+            base_url = comfy_base.rstrip('/')
+            if kind == 'audio':
+                return [
+                    (f"{base_url}/upload/audio", 'audio'),
+                    (f"{base_url}/upload", 'audio'),
+                    (f"{base_url}/upload", 'file'),
+                    (f"{base_url}/upload/image", 'image'),
+                ]
+            if kind == 'video':
+                return [
+                    (f"{base_url}/upload/video", 'video'),
+                    (f"{base_url}/upload", 'video'),
+                    (f"{base_url}/upload", 'file'),
+                ]
+            # 默认 image
+            return [
+                (f"{base_url}/upload/image", 'image'),
+                (f"{base_url}/upload", 'image'),
+                (f"{base_url}/upload", 'file'),
+            ]
 
-        # 更可读的错误：必须 JSON
-        if r.status_code != 200 or not r.headers.get('content-type','').startswith('application/json'):
-            raise RuntimeError(f"Non-JSON from {url}: status={r.status_code} ct={r.headers.get('content-type')} body_snip={r.text[:200]!r}")
-        data = r.json()
-        name = data.get('name') or data.get('filename')
-        if not name and isinstance(data.get('files'), list) and data['files']:
-            name = data['files'][0].get('filename') or data['files'][0].get('name')
-        if name:
-            return name
-        raise RuntimeError(f"Unexpected /upload response: {data}")
+        last_error = None
+
+        for url, field in _build_candidates():
+            try:
+                if hasattr(file_handle, 'seek'):
+                    file_handle.seek(0)
+                files = {field: (upload_name, file_handle, mime)} if mime else {field: (upload_name, file_handle)}
+                r = _requests.post(url, files=files, data={'type': 'input', 'subfolder': ''}, timeout=120)
+            except _requests.RequestException as exc:
+                last_error = f"请求 {url} 失败：{exc}"
+                continue
+
+            ct = r.headers.get('content-type', '')
+            if r.status_code == 200 and ct.startswith('application/json'):
+                data = r.json() or {}
+                name = data.get('name') or data.get('filename')
+                if not name and isinstance(data.get('files'), list) and data['files']:
+                    name = data['files'][0].get('filename') or data['files'][0].get('name')
+                if name:
+                    return name
+                last_error = f"接口 {url} 返回异常数据：{data}"
+                continue
+
+            snippet = (r.text or '').replace('\n', ' ')[:200]
+            last_error = (
+                f"接口 {url} 返回 {r.status_code} {r.reason or ''}，Content-Type={ct or '未知'}"
+                + (f"，响应片段：{snippet}" if snippet else '')
+            )
+
+        raise RuntimeError(f"上传文件到 ComfyUI 失败：{last_error or '未知错误'}")
     finally:
         try:
             if fp and not fp.closed:
@@ -481,9 +702,14 @@ def _run_job(job_id):
     _update_job(job_id, status="running", progress=10, prompt_id=prompt_id)
 
     # poll history
-    deadline = time.time() + 600
+    wf_name = (j.get("workflow") or "").lower()
+    long_running_prefixes = ("l15", "l6", "l16_1", "l16_2")
+    wait_seconds = 1800 if any(wf_name.startswith(prefix) for prefix in long_running_prefixes) else 600
+    deadline = time.time() + wait_seconds
     outputs = []
     file_outputs = []  # 记录可下载产物，用于 ZIP
+    seen_files = set()
+    last_item = None
     while time.time() < deadline:
         try:
             h = requests.get(f"{comfy}/history/{prompt_id}", timeout=30)
@@ -506,43 +732,67 @@ def _run_job(job_id):
             _bump_progress(j, step=2, ceiling=90)
             time.sleep(1)
             continue
-        if item.get("node_errors"):
-            _update_job(job_id, status="error", error=str(item.get("node_errors")))
+        last_item = item
+        node_errors = item.get("node_errors")
+        if node_errors:
+            message = _summarize_node_errors(node_errors)
+            error_msg = message or "ComfyUI 返回节点错误"
+            _update_job(
+                job_id,
+                status="error",
+                error=_localize_error_message(error_msg) or error_msg,
+                progress=100,
+                done_at=time.time(),
+                outputs=[],
+                file_outputs=[],
+            )
+            return
+        status_info = item.get("status")
+        if _history_status_failed(status_info):
+            status_message = _extract_history_error(item) or "ComfyUI 返回错误状态"
+            localized = _localize_error_message(status_message) or status_message
+            _update_job(
+                job_id,
+                status="error",
+                error=localized,
+                progress=100,
+                done_at=time.time(),
+                outputs=[],
+                file_outputs=[],
+            )
             return
         outs = item.get("outputs") or {}
         for node_out in outs.values():
+            if not isinstance(node_out, dict):
+                continue
+
             for img in node_out.get("images", []):
-                artifact = {
-                    "kind": "image",
-                    "filename": img.get("filename"),
-                    "subfolder": img.get("subfolder", ""),
-                    "type": img.get("type", "output")
-                }
-                outputs.append(artifact)
-                file_outputs.append(artifact)
+                _add_artifact(_normalize_artifact(img, default_kind="image"), outputs, file_outputs, seen_files)
+
+            for video in node_out.get("videos", []):
+                _add_artifact(_normalize_artifact(video, default_kind="video"), outputs, file_outputs, seen_files)
 
             for audio in node_out.get("audio", []):
-                artifact = {
-                    "kind": "audio",
-                    "filename": audio.get("filename"),
-                    "subfolder": audio.get("subfolder", ""),
-                    "type": audio.get("type", "output"),
-                    "format": audio.get("format") or audio.get("mime", "")
-                }
-                outputs.append(artifact)
-                file_outputs.append(artifact)
+                _add_artifact(_normalize_artifact(audio, default_kind="audio"), outputs, file_outputs, seen_files)
+
+            for gif in node_out.get("gifs", []):
+                _add_artifact(_normalize_artifact(gif, default_kind="video"), outputs, file_outputs, seen_files)
 
             for file_item in node_out.get("files", []):
-                artifact = {
-                    "kind": file_item.get("kind") or "file",
-                    "filename": file_item.get("filename"),
-                    "subfolder": file_item.get("subfolder", ""),
-                    "type": file_item.get("type", "output"),
-                }
-                outputs.append(artifact)
-                file_outputs.append(artifact)
+                _add_artifact(_normalize_artifact(file_item), outputs, file_outputs, seen_files)
 
-            for text_item in node_out.get("text", []):
+            single_file = node_out.get("file")
+            if single_file:
+                _add_artifact(_normalize_artifact(single_file), outputs, file_outputs, seen_files)
+
+            single_image = node_out.get("image")
+            if single_image:
+                _add_artifact(_normalize_artifact(single_image, default_kind="image"), outputs, file_outputs, seen_files)
+
+            text_items = node_out.get("text") or []
+            if isinstance(text_items, dict):
+                text_items = [text_items]
+            for text_item in text_items:
                 if isinstance(text_item, dict):
                     content = text_item.get("text") or text_item.get("content") or ""
                     extra = {k: v for k, v in text_item.items() if k not in {"text", "content"}}
@@ -561,7 +811,51 @@ def _run_job(job_id):
             _bump_progress(j)
         time.sleep(1)
     if not outputs:
-        _update_job(job_id, status="timeout", progress=100, done_at=time.time())
+        if isinstance(last_item, dict):
+            node_errors = last_item.get("node_errors")
+            if node_errors:
+                message = _summarize_node_errors(node_errors)
+                error_msg = message or "ComfyUI 返回节点错误"
+                _update_job(
+                    job_id,
+                    status="error",
+                    error=_localize_error_message(error_msg) or error_msg,
+                    progress=100,
+                    done_at=time.time(),
+                    outputs=[],
+                    file_outputs=[],
+                )
+                return
+            status_info = last_item.get("status")
+            if _history_status_failed(status_info):
+                status_message = _extract_history_error(last_item) or "ComfyUI 返回错误状态"
+                localized = _localize_error_message(status_message) or status_message
+                _update_job(
+                    job_id,
+                    status="error",
+                    error=localized,
+                    progress=100,
+                    done_at=time.time(),
+                    outputs=[],
+                    file_outputs=[],
+                )
+                return
+            status_info = status_info if isinstance(status_info, dict) else {}
+        else:
+            status_info = {}
+        state_val = status_info.get("status") if isinstance(status_info, dict) else None
+        if state_val in {"success", "finished", "completed"}:
+            _update_job(job_id, status="finished", progress=100, outputs=[], done_at=time.time(), file_outputs=[])
+            return
+        _update_job(
+            job_id,
+            status="timeout",
+            progress=100,
+            done_at=time.time(),
+            error="轮询超时：长时间未收到服务器响应，任务可能仍在后台运行，请稍后查看历史记录。",
+            outputs=[],
+            file_outputs=file_outputs,
+        )
         return
     _update_job(job_id, status="finished", progress=100, outputs=outputs, done_at=time.time(), file_outputs=file_outputs)
 

--- a/app/pages.py
+++ b/app/pages.py
@@ -1,12 +1,16 @@
 from flask import Blueprint, render_template, redirect, url_for, session
 
+from .jobs2 import _list_workflows_impl
+
 pages_bp = Blueprint("pages", __name__)
 
 @pages_bp.get("/")
 def home():
     if "user" not in session:
         return redirect(url_for("pages.login_page"))
-    return render_template("main.html")
+    workflows = _list_workflows_impl()
+    default_workflow = workflows[0]["workflow"] if workflows else ""
+    return render_template("main.html", workflows=workflows, default_workflow=default_workflow)
 
 
 @pages_bp.get("/login")

--- a/static/app.css
+++ b/static/app.css
@@ -43,8 +43,12 @@ input:focus, textarea:focus, select:focus{border-color:#3f62a8; box-shadow:0 0 0
 .btn:hover{filter:brightness(1.05)}
 .btn.ghost{background:transparent; border-color:var(--border); color:var(--text)}
 .btn.danger{background:linear-gradient(90deg, #ff6b7a, #ff4d65)}
+.btn:disabled{opacity:.6; cursor:not-allowed; filter:none}
+.btn:disabled:hover{filter:none}
 
 .muted{color:var(--muted)}
+.error-text{color:var(--danger);}
+.notice{margin:8px 0; padding:10px 12px; border-radius:10px; border:1px solid var(--border); background:rgba(106,164,255,.12); color:var(--accent); line-height:1.5;}
 pre{background:#0b1324; border:1px solid var(--border); border-radius:12px; padding:12px; overflow:auto}
 
 /* auth pages */
@@ -66,6 +70,7 @@ th{background:#0b1324; color:var(--muted); text-align:left}
 .artifact{display:inline-block; vertical-align:top; margin:6px; padding:10px; border:1px solid var(--border); border-radius:12px; background:#0b1324b3; max-width:260px; min-width:200px;}
 .artifact img.thumb{display:block; margin:0 auto 8px;}
 .artifact audio{width:100%; margin:8px 0;}
+.artifact video{width:100%; margin:8px 0; border-radius:8px; background:#000;}
 .artifact-caption{font-size:13px; color:var(--muted); margin-bottom:6px;}
 .artifact-text{max-width:420px; display:block;}
 .artifact-text pre{margin:0; white-space:pre-wrap; word-break:break-word;}

--- a/static/app_main.js
+++ b/static/app_main.js
@@ -254,52 +254,376 @@ function renderField(container, f){
   container.appendChild(wrap);
 }
 
-
+async function parseJsonResponse(res, context){
+  const raw = await res.text();
+  if(!raw){
+    if(res.ok){ return {}; }
+    throw new Error(`${context}：服务器返回空响应（${res.status} ${res.statusText}）`);
+  }
+  try{
+    return JSON.parse(raw);
+  }catch(err){
+    const type = res.headers && res.headers.get ? (res.headers.get('content-type') || '未知类型') : '未知类型';
+    const snippet = raw.replace(/\s+/g, ' ').trim().slice(0, 160);
+    const extra = snippet ? ` 内容片段：${snippet}` : '';
+    throw new Error(`${context}：服务器返回了无法解析的响应（${res.status} ${res.statusText}，${type}）。${extra}`);
+  }
+}
 
 async function authGuard(){
   const r = await fetch('/auth/status');
   if(r.status === 401){ location.href = '/login'; return false; }
-  const j = await r.json();
+  const j = await parseJsonResponse(r, '获取登录状态');
   const bar = document.getElementById('userbar');
   const adminLink = j.role==='admin' ? ` | <a class="pill" href="/admin/settings">后台</a>` : '';
   bar.innerHTML = `已登录：${(j.user||'')}${adminLink} <a class="pill" href="/logout_page" style="margin-left:8px">退出</a>`;
   return true;
 }
 
+const LONG_WORKFLOW_PREFIXES = ['L15', 'L6', 'L16_1', 'L16_2'];
+const LIMITED_PREVIEW_WORKFLOWS = ['L16_2'];
+const AUDIO_SYNC_WORKFLOWS = ['L15_2', 'L16_1', 'L16_2'];
+
+function isLongWorkflowName(name){
+  const upper = (name || '').toUpperCase();
+  return LONG_WORKFLOW_PREFIXES.some(prefix => upper.startsWith(prefix.toUpperCase()));
+}
+
+function shouldLimitPreview(name){
+  const upper = (name || '').toUpperCase();
+  return LIMITED_PREVIEW_WORKFLOWS.some(prefix => upper.startsWith(prefix.toUpperCase()));
+}
+
+function requiresAudioSync(name){
+  const upper = (name || '').toUpperCase();
+  return AUDIO_SYNC_WORKFLOWS.some(prefix => upper.startsWith(prefix.toUpperCase()));
+}
+
+function applyAudioDurationSync(workflowName){
+  if(!requiresAudioSync(workflowName)){ return; }
+  const form = document.getElementById('jobForm');
+  if(!form){ return; }
+  const audioField = form.querySelector('input[name="audio_duration"]');
+  const durationField = form.querySelector('input[name="duration"]');
+  if(!audioField || !durationField){ return; }
+
+  const syncToAudio = () => {
+    const audioVal = parseFloat(audioField.value);
+    if(!Number.isFinite(audioVal) || audioVal <= 0){ return; }
+    if(durationField.dataset.manualDuration === '1'){
+      const current = parseFloat(durationField.value);
+      if(!Number.isFinite(current) || current <= 0){
+        durationField.value = audioVal;
+      }
+      return;
+    }
+    durationField.value = audioVal;
+  };
+
+  audioField.addEventListener('input', () => {
+    delete durationField.dataset.manualDuration;
+    syncToAudio();
+  });
+  audioField.addEventListener('change', () => {
+    delete durationField.dataset.manualDuration;
+    syncToAudio();
+  });
+
+  const markManual = () => {
+    durationField.dataset.manualDuration = '1';
+  };
+
+  durationField.addEventListener('input', markManual);
+  durationField.addEventListener('change', markManual);
+
+  syncToAudio();
+}
+
+function filterOutputsForPreview(outputs, workflowName){
+  if(!shouldLimitPreview(workflowName)){
+    return outputs || [];
+  }
+  const result = [];
+  let firstImageShown = false;
+  (outputs || []).forEach(o => {
+    if(!o){ return; }
+    if(o.kind === 'video'){
+      result.push(o);
+      return;
+    }
+    if(o.kind === 'image'){
+      if(!firstImageShown){
+        result.push(o);
+        firstImageShown = true;
+      }
+      return;
+    }
+  });
+  return result.length ? result : (outputs || []);
+}
+
+function applyLongWorkflowNotice(workflowName){
+  const notice = document.getElementById('longWorkflowNotice');
+  if(!notice){ return; }
+  if(isLongWorkflowName(workflowName)){
+    notice.style.display = '';
+  }else{
+    notice.style.display = 'none';
+  }
+}
+
+function getCurrentWorkflow(){
+  const input = document.getElementById('wfInput');
+  return input ? (input.value || '') : '';
+}
+
+function getCooldownSecondsForWorkflow(workflowName){
+  return isLongWorkflowName(workflowName) ? 300 : 120;
+}
+
 async function loadWorkflows(){
   const sel = document.getElementById('wfSelect');
-  const resp = await fetch('/api/workflows'); const j = await resp.json();
-  sel.innerHTML = '';
-  (j.items||[]).forEach(it=>{ const o=document.createElement('option'); o.value=it.workflow; o.textContent=it.workflow+(it.has_form?'':' (无表单)'); sel.appendChild(o)});
-  if(j.items&&j.items.length){ sel.value = j.items[0].workflow; document.getElementById('wfInput').value = sel.value; await loadForm(sel.value); }
-  sel.onchange = async ()=>{ document.getElementById('wfInput').value = sel.value; await loadForm(sel.value); };
+  const wfInput = document.getElementById('wfInput');
+  const statusEl = document.getElementById('wfStatus');
+  if(!sel){ return; }
+  const showStatus = (message, isError=false) => {
+    if(!statusEl){ return; }
+    if(message){
+      statusEl.style.display = '';
+      statusEl.textContent = message;
+    }else{
+      statusEl.textContent = '';
+      statusEl.style.display = 'none';
+    }
+    statusEl.classList.toggle('error-text', Boolean(isError && message));
+  };
+  const currentWorkflow = () => (sel.value || (wfInput ? wfInput.value : '') || '').trim();
+  let selected = currentWorkflow();
+
+  try{
+    const resp = await fetch('/api/workflows');
+    if(resp.status === 401){ location.href = '/login'; return; }
+    const data = await parseJsonResponse(resp, '加载工作流列表');
+    const items = Array.isArray(data.items) ? data.items : [];
+    if(items.length){
+      const prev = selected;
+      sel.innerHTML = '';
+      items.forEach(it => {
+        const option = document.createElement('option');
+        option.value = it.workflow;
+        option.textContent = `${it.workflow}${it.has_form ? '' : ' (无表单)'}`;
+        sel.appendChild(option);
+      });
+      if(prev && items.some(it => it.workflow === prev)){
+        selected = prev;
+      }else{
+        selected = items[0].workflow;
+      }
+      sel.value = selected;
+      showStatus('');
+    }else{
+      if(!sel.options.length){
+        const option = document.createElement('option');
+        option.value = '';
+        option.disabled = true;
+        option.selected = true;
+        option.textContent = '暂无可用工作流';
+        sel.appendChild(option);
+      }
+      selected = '';
+      showStatus('暂无可用工作流', true);
+    }
+    if(data && data.ok === false && data.msg){
+      showStatus(`加载工作流失败：${data.msg}`, true);
+    }
+  }catch(err){
+    console.error(err);
+    const msg = err && err.message ? err.message : String(err);
+    showStatus(`加载工作流失败：${msg}`, true);
+  }
+
+  if(!selected){
+    const fallback = Array.from(sel.options || []).find(opt => !opt.disabled && opt.value);
+    if(fallback){
+      selected = fallback.value;
+      sel.value = selected;
+    }
+  }
+
+  if(wfInput){
+    wfInput.value = selected || '';
+  }
+
+  if(selected){
+    await loadForm(selected);
+    applyLongWorkflowNotice(selected);
+  }else{
+    applyLongWorkflowNotice('');
+    const area = document.getElementById('formFields');
+    if(area){
+      area.innerHTML = '<div class="muted">请选择工作流后再填写表单。</div>';
+    }
+  }
+
+  sel.onchange = async ()=>{
+    const value = sel.value || '';
+    if(wfInput){ wfInput.value = value; }
+    if(value){
+      await loadForm(value);
+      applyLongWorkflowNotice(value);
+    }else{
+      applyLongWorkflowNotice('');
+      const area = document.getElementById('formFields');
+      if(area){
+        area.innerHTML = '<div class="muted">请选择工作流后再填写表单。</div>';
+      }
+    }
+  };
+}
+
+let submitCooldownTimer = null;
+
+function startSubmitCooldown(seconds, prefixText){
+  const submitBtn = document.querySelector('#jobForm button[type="submit"]');
+  const respEl = document.getElementById('createResp');
+  if(!submitBtn || !respEl){ return; }
+  if(submitCooldownTimer){
+    clearInterval(submitCooldownTimer);
+    submitCooldownTimer = null;
+  }
+  let remaining = Math.max(0, seconds|0);
+  const formatMessage = () => {
+    const countdownText = `您在“${remaining}”秒之后才能再次提交`;
+    if(prefixText){
+      const suffix = prefixText.endsWith('。') ? '' : '。';
+      respEl.textContent = `${prefixText}${suffix}${countdownText}`;
+    }else{
+      respEl.textContent = countdownText;
+    }
+  };
+  submitBtn.disabled = true;
+  formatMessage();
+  if(remaining <= 0){
+    submitBtn.disabled = false;
+    if(prefixText){ respEl.textContent = prefixText; }
+    return;
+  }
+  submitCooldownTimer = setInterval(() => {
+    remaining -= 1;
+    if(remaining <= 0){
+      clearInterval(submitCooldownTimer);
+      submitCooldownTimer = null;
+      submitBtn.disabled = false;
+      if(prefixText){
+        respEl.textContent = prefixText;
+      }else{
+        respEl.textContent = '';
+      }
+      return;
+    }
+    formatMessage();
+  }, 1000);
 }
 
 async function loadForm(wfname){
-  const area = document.getElementById('formFields'); area.innerHTML='';
-  const r = await fetch(`/api/workflows/${encodeURIComponent(wfname)}/form`); const j = await r.json();
-  const fields = (j.form && j.form.fields) || [];
-  if(!fields.length){ area.innerHTML = '<div class="muted">该工作流暂未提供表单定义，可直接提交。</div>'; }
-  fields.forEach(f=>renderField(area, f));
+  const area = document.getElementById('formFields');
+  if(!area){ return; }
+  if(!wfname){
+    area.innerHTML = '<div class="muted">请选择工作流后再填写表单。</div>';
+    return;
+  }
+  area.innerHTML = '<div class="muted">正在加载表单…</div>';
+  try{
+    const r = await fetch(`/api/workflows/${encodeURIComponent(wfname)}/form`);
+    if(r.status === 401){ location.href = '/login'; return; }
+    const j = await parseJsonResponse(r, '加载表单');
+    const fields = (j.form && j.form.fields) || [];
+    area.innerHTML = '';
+    if(!fields.length){
+      area.innerHTML = '<div class="muted">该工作流暂未提供表单定义，可直接提交。</div>';
+      return;
+    }
+    fields.forEach(f=>renderField(area, f));
+    applyAudioDurationSync(wfname);
+  }catch(err){
+    const msg = err && err.message ? err.message : String(err);
+    area.innerHTML = `<div class="error-text">加载表单失败：${escapeHtml(msg)}</div>`;
+  }
 }
 
 function bindSubmit(){
-  document.getElementById('jobForm').addEventListener('submit', async (e)=>{
+  const form = document.getElementById('jobForm');
+  const submitBtn = form.querySelector('button[type="submit"]');
+  form.addEventListener('submit', async (e)=>{
     e.preventDefault();
+    if(submitBtn){ submitBtn.disabled = true; }
+    const respBox = document.getElementById('createResp');
+    if(respBox){ respBox.textContent = ''; }
+    const wfName = getCurrentWorkflow();
+    if(requiresAudioSync(wfName)){
+      const audioField = form.querySelector('input[name="audio_duration"]');
+      const durationField = form.querySelector('input[name="duration"]');
+      if(audioField && durationField){
+        const audioVal = parseFloat(audioField.value);
+        const durationVal = parseFloat(durationField.value);
+        if(Number.isFinite(audioVal) && Number.isFinite(durationVal)){
+          if(audioVal <= 0 || durationVal <= 0){
+            if(submitBtn){ submitBtn.disabled = false; }
+            if(respBox){ respBox.textContent = '提交失败：音频时长和生成时长必须大于 0。'; }
+            (durationVal <= 0 ? durationField : audioField).focus();
+            return;
+          }
+          const maxAllowed = Math.max(audioVal * 2, audioVal + 10);
+          if(durationVal > maxAllowed){
+            if(submitBtn){ submitBtn.disabled = false; }
+            if(respBox){ respBox.textContent = '提交失败：生成时长需要与音频时长接近，请调整“生成时长(秒)”字段。'; }
+            durationField.focus();
+            return;
+          }
+        }
+      }
+    }
     const fd = new FormData(e.target);
+    let cooldownStarted = false;
     try{
       const res = await fetch('/api/jobs', {method:'POST', body:fd});
-      const j = await res.json();
-      document.getElementById('createResp').textContent = JSON.stringify(j);
-      if(j.ok){ document.getElementById('jobId').value = j.job_id; }
-    }catch(err){ document.getElementById('createResp').textContent = err+''; }
+      let j;
+      try{
+        j = await parseJsonResponse(res, '提交任务');
+      }catch(parseErr){
+        document.getElementById('createResp').textContent = `提交失败：${parseErr.message || parseErr}`;
+        return;
+      }
+      if(!res.ok && !j.ok){
+        const msg = j && (j.error || j.message);
+        const fallback = `服务器返回错误（${res.status} ${res.statusText}）`;
+        document.getElementById('createResp').textContent = `提交失败：${msg || fallback}`;
+        return;
+      }
+      if(j.ok){
+        if(j.job_id){ document.getElementById('jobId').value = j.job_id; }
+        const successText = `提交成功，任务 ID：${j.job_id || ''}`.trim();
+        const wfName = getCurrentWorkflow();
+        const cooldownSeconds = getCooldownSecondsForWorkflow(wfName);
+        startSubmitCooldown(cooldownSeconds, successText);
+        applyLongWorkflowNotice(wfName);
+        cooldownStarted = true;
+      }else{
+        const msg = j.error ? `提交失败：${j.error}` : '提交失败，请稍后重试。';
+        document.getElementById('createResp').textContent = msg;
+      }
+    }catch(err){
+      document.getElementById('createResp').textContent = `提交失败：${err}`;
+    }finally{
+      if(!cooldownStarted && submitBtn){ submitBtn.disabled = false; }
+    }
   });
 }
 
 async function updateQueue(){
   try{
     const r = await fetch('/api/queue');
-    const j = await r.json();
+    const j = await parseJsonResponse(r, '获取队列信息');
     if(j && typeof j.queued !== 'undefined'){
       document.getElementById('queueCount').textContent = j.queued;
     }
@@ -311,13 +635,40 @@ function bindPoll(){
     const id = document.getElementById('jobId').value.trim();
     if(!id) return;
     async function step(){
-      const r = await fetch(`/api/jobs/${id}/status`);
-      const j = await r.json();
+      let j;
+      try{
+        const r = await fetch(`/api/jobs/${id}/status`);
+        j = await parseJsonResponse(r, '获取任务状态');
+      }catch(err){
+        console.error(err);
+        document.getElementById('stateText').textContent = '获取任务状态失败';
+        const detailErr = document.getElementById('detailsPre');
+        if(detailErr) detailErr.textContent = `${err}`;
+        return;
+      }
       // 仅在详情中保留原始 JSON
       const detail = document.getElementById('detailsPre');
       if(detail) detail.textContent = JSON.stringify(j,null,2);
       // 顶部简要信息
       document.getElementById('stateText').textContent = j.status || '-';
+      if(j.workflow){
+        applyLongWorkflowNotice(j.workflow);
+      }else{
+        applyLongWorkflowNotice(getCurrentWorkflow());
+      }
+      const jobErrorEl = document.getElementById('jobError');
+      if(jobErrorEl){
+        let message = '';
+        if(j.status === 'error'){
+          message = j.error ? `任务失败：${j.error}` : '任务失败：未返回具体原因。';
+        }else if(j.status === 'timeout'){
+          message = j.error ? `任务超时：${j.error}` : '任务超时：长时间未收到服务器响应。';
+        }else if(j.error && j.status !== 'finished'){
+          message = j.error.startsWith('提示：') ? j.error : `提示：${j.error}`;
+        }
+        jobErrorEl.textContent = message;
+        jobErrorEl.style.display = message ? '' : 'none';
+      }
       updateQueue();
       const pw = document.getElementById('progWrap');
       const pb = document.getElementById('progBar');
@@ -330,12 +681,20 @@ function bindPoll(){
         pw.style.display = show ? 'block' : 'none';
       }
       if(j.ok && Array.isArray(j.outputs) && j.outputs.length){
-        const outputs = j.outputs || [];
-        const fileOutputs = (j.file_outputs || outputs).filter(o => o && o.filename);
+        const workflowName = j.workflow || getCurrentWorkflow();
+        const rawOutputs = j.outputs || [];
+        const outputs = filterOutputsForPreview(rawOutputs, workflowName);
+        const fileOutputs = (j.file_outputs || rawOutputs).filter(o => o && o.filename);
         const parts = outputs.map(o => {
           if(!o){ return ''; }
           if(o.kind === 'text' && o.text){
             return `<div class=\"artifact artifact-text\"><div class=\"artifact-caption\">文本输出</div><pre>${escapeHtml(o.text)}</pre></div>`;
+          }
+          if(o.kind === 'video' && o.filename){
+            const url = `/api/jobs/${id}/comfy/view?filename=${encodeURIComponent(o.filename)}&subfolder=${encodeURIComponent(o.subfolder||'')}&type=${encodeURIComponent(o.type||'output')}`;
+            const dl = `/api/jobs/${id}/download?filename=${encodeURIComponent(o.filename)}&subfolder=${encodeURIComponent(o.subfolder||'')}&type=${encodeURIComponent(o.type||'output')}`;
+            const type = o.format || 'video/mp4';
+            return `<div class=\"artifact artifact-video\"><div class=\"artifact-caption\">视频输出：${escapeHtml(o.filename || '')}</div><video controls preload=\"metadata\" src=\"${url}\" type=\"${escapeHtml(type)}\"></video><div><a href=\"${dl}\">下载</a></div></div>`;
           }
           if(o.kind === 'audio' && o.filename){
             const url = `/api/jobs/${id}/comfy/view?filename=${encodeURIComponent(o.filename)}&subfolder=${encodeURIComponent(o.subfolder||'')}&type=${encodeURIComponent(o.type||'output')}`;

--- a/templates/main.html
+++ b/templates/main.html
@@ -17,10 +17,19 @@
         <h3>选择工作流并填写表单</h3>
         <div>
           <label>工作流</label>
-          <select id="wfSelect"></select>
+          <select id="wfSelect">
+            {% if workflows %}
+              {% for item in workflows %}
+                <option value="{{ item.workflow }}"{% if loop.first %} selected{% endif %}>{{ item.workflow }}{% if not item.has_form %} (无表单){% endif %}</option>
+              {% endfor %}
+            {% else %}
+              <option value="" disabled selected>暂无可用工作流</option>
+            {% endif %}
+          </select>
+          <div id="wfStatus" class="muted" style="display:none"></div>
         </div>
         <form id="jobForm">
-          <input type="hidden" name="workflow" id="wfInput" value="default.json" />
+          <input type="hidden" name="workflow" id="wfInput" value="{{ default_workflow or '' }}" />
           <input type="hidden" name="form_mode" value="1" />
           <div id="formFields"></div>
           <div style="margin-top:8px">
@@ -39,6 +48,10 @@
         <div id="topline" class="muted" style="margin:6px 0 8px">
           排队：<b id="queueCount">-</b> · 状态：<b id="stateText">-</b>
         </div>
+        <div id="longWorkflowNotice" class="notice" style="display:none">
+          由于生成视频时间较长，请耐心等待，不要连续点击生成按钮。
+        </div>
+        <div id="jobError" class="error-text" style="display:none;margin:6px 0"></div>
         <div id="progWrap" style="display:none;margin:8px 0 6px">
           <div style="height:10px;background:#0b1324;border:1px solid var(--border);border-radius:8px;overflow:hidden">
             <div id="progBar" style="height:100%;width:0;background:linear-gradient(90deg, var(--primary), var(--accent))"></div>

--- a/workflows/L15_2_API.form.json
+++ b/workflows/L15_2_API.form.json
@@ -58,15 +58,17 @@
       "name": "audio_duration",
       "label": "音频时长(秒)",
       "type": "number",
-      "default": 10.000000000000002,
-      "step": 0.1
+      "default": 10,
+      "step": 0.1,
+      "help": "请填写音频实际时长"
     },
     {
       "name": "duration",
       "label": "生成时长(秒)",
       "type": "number",
-      "default": 1000,
-      "step": 0.1
+      "default": 10,
+      "step": 0.1,
+      "help": "建议与音频时长一致，过长会导致失败"
     },
     {
       "name": "expand_ratio",

--- a/workflows/L16_1_API.form.json
+++ b/workflows/L16_1_API.form.json
@@ -59,14 +59,16 @@
       "label": "音频时长(秒)",
       "type": "number",
       "default": 14,
-      "step": 0.1
+      "step": 0.1,
+      "help": "请填写音频实际时长"
     },
     {
       "name": "duration",
       "label": "生成时长(秒)",
       "type": "number",
-      "default": 10000,
-      "step": 0.1
+      "default": 14,
+      "step": 0.1,
+      "help": "建议与音频时长一致，过长会导致失败"
     },
     {
       "name": "expand_ratio",

--- a/workflows/L16_2_API.form.json
+++ b/workflows/L16_2_API.form.json
@@ -58,15 +58,17 @@
       "name": "audio_duration",
       "label": "音频时长(秒)",
       "type": "number",
-      "default": 2.0000000000000004,
-      "step": 0.1
+      "default": 2,
+      "step": 0.1,
+      "help": "请填写音频实际时长"
     },
     {
       "name": "duration",
       "label": "生成时长(秒)",
       "type": "number",
-      "default": 10000,
-      "step": 0.1
+      "default": 2,
+      "step": 0.1,
+      "help": "建议与音频时长一致，过长会导致失败"
     },
     {
       "name": "expand_ratio",

--- a/workflows/L7_API.form.json
+++ b/workflows/L7_API.form.json
@@ -13,7 +13,7 @@
     {"name": "height", "label": "高度", "type": "integer", "default": 720},
     {"name": "vae_name", "label": "VAE", "type": "text", "default": "ae.safetensors"},
     {"name": "unet_name", "label": "UNet", "type": "text", "default": "flux1-dev-fp8.safetensors"},
-    {"name": "lora_name", "label": "LoRA", "type": "text", "default": "F.1国风汉服_Flux_hanfu测试?.safetensors"},
+    {"name": "lora_name", "label": "LoRA", "type": "text", "default": "F.1国风汉服_Flux_hanfu测试版.safetensors"},
     {"name": "strength_model", "label": "LoRA 强度", "type": "number", "default": 1.0},
     {"name": "filename_prefix", "label": "保存前缀", "type": "text", "default": "ComfyUI"}
   ],


### PR DESCRIPTION
## Summary
- include the L16_1/L16_2 video workflows in the long-running workflow list on the frontend so users see the wait notice and 300 second cooldown
- extend the backend long-running workflow window to cover L16_1/L16_2 so polling allows enough time to collect generated video files
- limit the L16_2 job preview to video outputs plus the first image while keeping the download options for every artifact
- synchronise the L15_2/L16 video workflow duration defaults with their audio lengths, guard form submission when the values diverge, and auto-sync the fields when editing
- surface ComfyUI node errors and failed statuses as localized failure messages, mark timeouts with guidance, and show the details in the task status panel

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e4850e8388832480653c00337a8650